### PR TITLE
Add MSBUILD Target File for Windows Batteries

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -181,9 +181,10 @@ Task("Pack")
           })
         .ToList();
     Information("Packing for {0}", Context.Environment.Platform.Dump());
-    if (!Context.Environment.Platform.IsUnix())
+    if (Context.Environment.Platform.Family == PlatformFamily.Windows)
     {
-      contentFiles.Append(new NuSpecContent{
+      Information("Adding Windows `.targets` file");
+      contentFiles.Add(new NuSpecContent{
         Source = "nuget_contents/IronRe2-Batteries.Windows.targets",
         Target = $"build/{nuGetPackageId}.targets",
       });

--- a/build.cake
+++ b/build.cake
@@ -180,6 +180,7 @@ Task("Pack")
             .TrimStart(new [] { '\\', '/' })
           })
         .ToList();
+    Information("Packing for {0}", Context.Environment.Platform.Dump());
     if (Context.Environment.Platform.Family == PlatformFamily.Windows)
     {
       contentFiles.Append(new NuSpecContent{

--- a/build.cake
+++ b/build.cake
@@ -170,6 +170,7 @@ Task("Pack")
       NoFetch = true,
     });
 
+    var nuGetPackageId = $"IronRe2-Batteries.{Context.Environment.Platform.Family}";
     var contentsPath = MakeAbsolute(Directory("bin/contents")).ToString();
     var contentFiles = GetFiles(contentsPath + "/**/*.*")
         .Select(file => new NuSpecContent {
@@ -178,13 +179,20 @@ Task("Pack")
             .Replace(contentsPath, "")
             .TrimStart(new [] { '\\', '/' })
           })
-        .ToArray();
+        .ToList();
+    if (Context.Environment.Platform.Family == PlatformFamily.Windows)
+    {
+      contentFiles.Append(new NuSpecContent{
+        Source = "nuget_contents/IronRe2-Batteries.Windows.targets",
+        Target = $"build/{nuGetPackageId}.targets",
+      });
+    }
     foreach (var file in contentFiles)
     {
         Information("including {0}", file.Dump());
     }
     NuGetPack(new NuGetPackSettings {
-      Id = $"IronRe2-Batteries.{Context.Environment.Platform.Family}",
+      Id = nuGetPackageId,
       Version = versionInfo.NuGetVersionV2,
       Title = "IronRe2 Batteries",
       Authors = new[] { CrispGroupName },

--- a/build.cake
+++ b/build.cake
@@ -181,7 +181,7 @@ Task("Pack")
           })
         .ToList();
     Information("Packing for {0}", Context.Environment.Platform.Dump());
-    if (Context.Environment.Platform.Family == PlatformFamily.Windows)
+    if (!Context.Environment.Platform.IsUnix())
     {
       contentFiles.Append(new NuSpecContent{
         Source = "nuget_contents/IronRe2-Batteries.Windows.targets",

--- a/nuget_contents/IronRe2-Batteries.Windows.targets
+++ b/nuget_contents/IronRe2-Batteries.Windows.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\cre2.dll">
+      <Link>cre2.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds a targets file so that batteries are copied on Framework builds.