### PR TITLE
Enforce static linking and update CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,13 @@ target_link_libraries(cre2 PRIVATE
   re2
 )
 
-# Link re2 as a whole archive.
+# Platform-specific whole-archive linking for re2.
 if(MSVC)
   target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
-else()
-  # Remove the quotes so the generator expression is recognized.
-  target_link_libraries(cre2 PRIVATE $<LINK_WHOLE_ARCHIVE:re2>)
+elseif(APPLE)
+  # On macOS, force linking the entire static library using -force_load.
+  target_link_libraries(cre2 PRIVATE "-Wl,-force_load" $<TARGET_FILE:re2>)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # On GNU or Clang (Linux), use --whole-archive flags.
+  target_link_libraries(cre2 PRIVATE "-Wl,--whole-archive" re2 "-Wl,--no-whole-archive")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,59 +4,66 @@ project(IronRe-Batteries)
 # Require C++17.
 set(CMAKE_CXX_STANDARD 17)
 
-# Force static linking and turn off shared libraries globally.
+# Global settings: force static linking and disable testing.
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_TESTING OFF)
 set(RE2_BUILD_TESTING OFF)
 
-
-  # This forces /MT for Release and /MTd for Debug.
+# MSVC-specific settings.
+if(MSVC)
+  # Force /MT for Release and /MTd for Debug.
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  # Also ensure RE2 builds as static.
+  # Ensure RE2 builds as static.
   set(RE2_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-
-
- add_definitions(-DRE2_STATIC)
-
-# Define the cre2 DLL target.
-
-  set_target_properties(cre2 PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-target_compile_definitions(cre2 PRIVATE
-    cre2_VERSION_INTERFACE_CURRENT=0
-    cre2_VERSION_INTERFACE_REVISION=0
-    cre2_VERSION_INTERFACE_AGE=0
-    cre2_VERSION_INTERFACE_STRING="0.0.0"
-)
-
-  target_compile_definitions(cre2 PRIVATE RE2_STATIC)
-
-target_include_directories(cre2 PRIVATE "${CMAKE_SOURCE_DIR}/thirdparty/re2")
-
-# Set up Abseil package location.
-if(WIN32)
-  # Use the vcpkg-installed Abseil from the static triplet.
-  set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
 endif()
 
+# Define RE2_STATIC globally.
+add_definitions(-DRE2_STATIC)
+
+# Define the cre2 DLL target.
+add_library(cre2 SHARED "${CMAKE_SOURCE_DIR}/thirdparty/cre2/src/cre2.cpp")
+
+# On Windows, export all symbols (for MSVC).
+if(WIN32)
+  set_target_properties(cre2 PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+# Set compile definitions for cre2.
+target_compile_definitions(cre2 PRIVATE
+  cre2_VERSION_INTERFACE_CURRENT=0
+  cre2_VERSION_INTERFACE_REVISION=0
+  cre2_VERSION_INTERFACE_AGE=0
+  cre2_VERSION_INTERFACE_STRING="0.0.0"
+  RE2_STATIC  # Ensure that cre2's translation units know we're linking statically.
+)
+
+# Specify include directories for cre2.
+target_include_directories(cre2 PRIVATE "${CMAKE_SOURCE_DIR}/thirdparty/re2")
+
+# Set up Abseil package location for Windows.
+if(WIN32)
+  set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
+endif()
 find_package(absl CONFIG REQUIRED)
 
 # Build re2 as a subdirectory.
 add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/re2" re2)
-# On Windows, ensure the re2 target sees RE2_STATIC.
-  target_compile_definitions(re2 PUBLIC RE2_STATIC)
 
-  # Link required Abseil static libraries.
-  target_link_libraries(cre2 PRIVATE 
-      absl::base
-      absl::strings
-      absl::synchronization
-      absl::time
-      re2
-  )
-  # On MSVC, force whole-archive linking of re2 so its entire static library is pulled in.
-  if(MSVC)
-    target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
-  else()
-    target_link_libraries(cre2 PRIVATE "$<LINK_WHOLE_ARCHIVE:re2>")
-  endif()
+# Ensure the re2 target sees RE2_STATIC.
+target_compile_definitions(re2 PUBLIC RE2_STATIC)
+
+# Link required libraries.
+target_link_libraries(cre2 PRIVATE 
+  absl::base
+  absl::strings
+  absl::synchronization
+  absl::time
+  re2
+)
+
+# On MSVC, force whole-archive linking for re2; otherwise, use a generator expression.
+if(MSVC)
+  target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
+else()
+  target_link_libraries(cre2 PRIVATE "$<LINK_WHOLE_ARCHIVE:re2>")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ endif()
 # Define RE2_STATIC globally.
 add_definitions(-DRE2_STATIC)
 
-# Define the cre2 DLL target.
+# Define the cre2 shared library target.
 add_library(cre2 SHARED "${CMAKE_SOURCE_DIR}/thirdparty/cre2/src/cre2.cpp")
 
-# On Windows, export all symbols (for MSVC).
+# On Windows, export all symbols for MSVC.
 if(WIN32)
   set_target_properties(cre2 PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
@@ -34,7 +34,7 @@ target_compile_definitions(cre2 PRIVATE
   cre2_VERSION_INTERFACE_REVISION=0
   cre2_VERSION_INTERFACE_AGE=0
   cre2_VERSION_INTERFACE_STRING="0.0.0"
-  RE2_STATIC  # Ensure that cre2's translation units know we're linking statically.
+  RE2_STATIC  # Mark as static linking.
 )
 
 # Specify include directories for cre2.
@@ -48,8 +48,6 @@ find_package(absl CONFIG REQUIRED)
 
 # Build re2 as a subdirectory.
 add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/re2" re2)
-
-# Ensure the re2 target sees RE2_STATIC.
 target_compile_definitions(re2 PUBLIC RE2_STATIC)
 
 # Link required libraries.
@@ -61,9 +59,10 @@ target_link_libraries(cre2 PRIVATE
   re2
 )
 
-# On MSVC, force whole-archive linking for re2; otherwise, use a generator expression.
+# Link re2 as a whole archive.
 if(MSVC)
   target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
 else()
-  target_link_libraries(cre2 PRIVATE "$<LINK_WHOLE_ARCHIVE:re2>")
+  # Remove the quotes so the generator expression is recognized.
+  target_link_libraries(cre2 PRIVATE $<LINK_WHOLE_ARCHIVE:re2>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,55 +17,53 @@ if(MSVC)
   set(RE2_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 endif()
 
-# Define RE2_STATIC globally.
+# Define RE2_STATIC globally so that RE2's headers treat the library as static.
 add_definitions(-DRE2_STATIC)
 
 # Define the cre2 shared library target.
 add_library(cre2 SHARED "${CMAKE_SOURCE_DIR}/thirdparty/cre2/src/cre2.cpp")
-
-# On Windows, export all symbols for MSVC.
-if(WIN32)
+if(MSVC)
   set_target_properties(cre2 PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
-# Set compile definitions for cre2.
 target_compile_definitions(cre2 PRIVATE
-  cre2_VERSION_INTERFACE_CURRENT=0
-  cre2_VERSION_INTERFACE_REVISION=0
-  cre2_VERSION_INTERFACE_AGE=0
-  cre2_VERSION_INTERFACE_STRING="0.0.0"
-  RE2_STATIC  # Mark as static linking.
+    cre2_VERSION_INTERFACE_CURRENT=0
+    cre2_VERSION_INTERFACE_REVISION=0
+    cre2_VERSION_INTERFACE_AGE=0
+    cre2_VERSION_INTERFACE_STRING="0.0.0"
+    RE2_STATIC  # Defined for all platforms.
 )
 
-# Specify include directories for cre2.
 target_include_directories(cre2 PRIVATE "${CMAKE_SOURCE_DIR}/thirdparty/re2")
 
-# Set up Abseil package location for Windows.
+# Set up Abseil package location (adjust the Windows path as necessary).
 if(WIN32)
   set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
 endif()
 find_package(absl CONFIG REQUIRED)
 
+# For UNIX (Linux/macOS), instruct RE2 to use system-installed Abseil.
+if(NOT WIN32)
+  set(RE2_USE_ABSEIL ON)
+  set(RE2_ABSEIL_SOURCE "system")
+endif()
+
 # Build re2 as a subdirectory.
 add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/re2" re2)
-target_compile_definitions(re2 PUBLIC RE2_STATIC)
 
-# Link required libraries.
+# Link libraries.
+# We link Abseil targets along with re2 so that cre2 is self-contained.
 target_link_libraries(cre2 PRIVATE 
-  absl::base
-  absl::strings
-  absl::synchronization
-  absl::time
-  re2
+      absl::base
+      absl::strings
+      absl::synchronization
+      absl::time
+      re2
 )
 
-# Platform-specific whole-archive linking for re2.
+# Platform-specific whole-archive linking for re2 (if needed on Windows).
 if(MSVC)
   target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
-elseif(APPLE)
-  # On macOS, force linking the entire static library using -force_load.
-  target_link_libraries(cre2 PRIVATE "-Wl,-force_load" $<TARGET_FILE:re2>)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  # On GNU or Clang (Linux), use --whole-archive flags.
-  target_link_libraries(cre2 PRIVATE "-Wl,--whole-archive" re2 "-Wl,--no-whole-archive")
+elseif(WIN32)
+  target_link_libraries(cre2 PRIVATE "$<LINK_WHOLE_ARCHIVE:re2>")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,66 +4,59 @@ project(IronRe-Batteries)
 # Require C++17.
 set(CMAKE_CXX_STANDARD 17)
 
-# Force static linking and turn off shared libraries and tests globally.
+# Force static linking and turn off shared libraries globally.
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_TESTING OFF)
 set(RE2_BUILD_TESTING OFF)
 
-# On MSVC, force the static runtime and ensure RE2 builds as a static library.
-if(MSVC)
+
+  # This forces /MT for Release and /MTd for Debug.
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  # Also ensure RE2 builds as static.
   set(RE2_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-endif()
 
-# Define RE2_STATIC so that RE2’s headers treat the library as static.
-add_definitions(-DRE2_STATIC)
 
-# Setup Abseil package location.
-# For Windows, use the vcpkg-installed Abseil from the static triplet.
-if(WIN32)
-  set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
-# For macOS, adjust this path to point to your static Abseil installation.
-
-find_package(absl CONFIG REQUIRED)
-
-# For non-Windows platforms, instruct RE2 to use system Abseil.
-if(NOT WIN32)
-  set(RE2_USE_ABSEIL ON)
-  set(RE2_ABSEIL_SOURCE "system")
-endif()
+ add_definitions(-DRE2_STATIC)
 
 # Define the cre2 DLL target.
-add_library(cre2 SHARED "${CMAKE_SOURCE_DIR}/thirdparty/cre2/src/cre2.cpp")
-if(MSVC)
+
   set_target_properties(cre2 PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()
 
 target_compile_definitions(cre2 PRIVATE
     cre2_VERSION_INTERFACE_CURRENT=0
     cre2_VERSION_INTERFACE_REVISION=0
     cre2_VERSION_INTERFACE_AGE=0
     cre2_VERSION_INTERFACE_STRING="0.0.0"
-    RE2_STATIC  # Ensure translation units know they’re linking statically.
 )
+
+  target_compile_definitions(cre2 PRIVATE RE2_STATIC)
 
 target_include_directories(cre2 PRIVATE "${CMAKE_SOURCE_DIR}/thirdparty/re2")
 
+# Set up Abseil package location.
+if(WIN32)
+  # Use the vcpkg-installed Abseil from the static triplet.
+  set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
+endif()
+
+find_package(absl CONFIG REQUIRED)
+
 # Build re2 as a subdirectory.
 add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/re2" re2)
+# On Windows, ensure the re2 target sees RE2_STATIC.
+  target_compile_definitions(re2 PUBLIC RE2_STATIC)
 
-# Ensure the re2 target sees RE2_STATIC.
-target_compile_definitions(re2 PUBLIC RE2_STATIC)
-
-# Link libraries.
-target_link_libraries(cre2 PRIVATE 
-    absl::base
-    absl::strings
-    absl::synchronization
-    absl::time
-    re2
-)
-
-# On MSVC, force whole-archive linking of re2 so its entire static library is pulled in.
-if(MSVC)
-  target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
-endif()
+  # Link required Abseil static libraries.
+  target_link_libraries(cre2 PRIVATE 
+      absl::base
+      absl::strings
+      absl::synchronization
+      absl::time
+      re2
+  )
+  # On MSVC, force whole-archive linking of re2 so its entire static library is pulled in.
+  if(MSVC)
+    target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
+  else()
+    target_link_libraries(cre2 PRIVATE "$<LINK_WHOLE_ARCHIVE:re2>")
+  endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,22 +4,32 @@ project(IronRe-Batteries)
 # Require C++17.
 set(CMAKE_CXX_STANDARD 17)
 
-# Force static linking and turn off shared libraries globally.
+# Force static linking and turn off shared libraries and tests globally.
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_TESTING OFF)
 set(RE2_BUILD_TESTING OFF)
 
-# On Windows/MSVC, force the static runtime.
+# On MSVC, force the static runtime and ensure RE2 builds as a static library.
 if(MSVC)
-  # This forces /MT for Release and /MTd for Debug.
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  # Also ensure RE2 builds as static.
   set(RE2_BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 endif()
 
-# On Windows, define RE2_STATIC so that RE2’s headers treat the library as static.
+# Define RE2_STATIC so that RE2’s headers treat the library as static.
+add_definitions(-DRE2_STATIC)
+
+# Setup Abseil package location.
+# For Windows, use the vcpkg-installed Abseil from the static triplet.
 if(WIN32)
-  add_definitions(-DRE2_STATIC)
+  set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
+# For macOS, adjust this path to point to your static Abseil installation.
+
+find_package(absl CONFIG REQUIRED)
+
+# For non-Windows platforms, instruct RE2 to use system Abseil.
+if(NOT WIN32)
+  set(RE2_USE_ABSEIL ON)
+  set(RE2_ABSEIL_SOURCE "system")
 endif()
 
 # Define the cre2 DLL target.
@@ -33,51 +43,27 @@ target_compile_definitions(cre2 PRIVATE
     cre2_VERSION_INTERFACE_REVISION=0
     cre2_VERSION_INTERFACE_AGE=0
     cre2_VERSION_INTERFACE_STRING="0.0.0"
+    RE2_STATIC  # Ensure translation units know they’re linking statically.
 )
-# On Windows, add RE2_STATIC so that cre2’s translation units know they’re linking statically.
-if(WIN32)
-  target_compile_definitions(cre2 PRIVATE RE2_STATIC)
-endif()
 
 target_include_directories(cre2 PRIVATE "${CMAKE_SOURCE_DIR}/thirdparty/re2")
 
-# Set up Abseil package location.
-if(WIN32)
-  # Use the vcpkg-installed Abseil from the static triplet.
-  set(absl_DIR "C:/vcpkg/installed/x64-windows-static/share/absl")
-endif()
-find_package(absl CONFIG REQUIRED)
-
-# For UNIX, tell RE2 to use Abseil from the system.
-if(NOT WIN32)
-  set(RE2_USE_ABSEIL ON)
-  set(RE2_ABSEIL_SOURCE "system")
-endif()
-
 # Build re2 as a subdirectory.
 add_subdirectory("${CMAKE_SOURCE_DIR}/thirdparty/re2" re2)
-# On Windows, ensure the re2 target sees RE2_STATIC.
-if(WIN32)
-  target_compile_definitions(re2 PUBLIC RE2_STATIC)
-endif()
+
+# Ensure the re2 target sees RE2_STATIC.
+target_compile_definitions(re2 PUBLIC RE2_STATIC)
 
 # Link libraries.
-if(WIN32)
-  # Link required Abseil static libraries.
-  target_link_libraries(cre2 PRIVATE 
-      absl::base
-      absl::strings
-      absl::synchronization
-      absl::time
-      re2
-  )
-  # On MSVC, force whole-archive linking of re2 so its entire static library is pulled in.
-  if(MSVC)
-    target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
-  else()
-    target_link_libraries(cre2 PRIVATE "$<LINK_WHOLE_ARCHIVE:re2>")
-  endif()
-else()
-  # On UNIX, simply link re2 normally.
-  target_link_libraries(cre2 PRIVATE re2)
+target_link_libraries(cre2 PRIVATE 
+    absl::base
+    absl::strings
+    absl::synchronization
+    absl::time
+    re2
+)
+
+# On MSVC, force whole-archive linking of re2 so its entire static library is pulled in.
+if(MSVC)
+  target_link_options(cre2 PRIVATE "/WHOLEARCHIVE:re2.lib")
 endif()


### PR DESCRIPTION
Updated CMake configuration to enforce static linking and disable shared libraries and tests globally. Added `RE2_STATIC` definition for static library treatment. Modified Abseil package setup for Windows using vcpkg and added `find_package` for Abseil. Adjusted handling for non-Windows platforms to use system Abseil. Updated target definitions for `cre2` and `re2` to include `RE2_STATIC` directly, removing Windows-specific checks. Restructured linking of Abseil static libraries to ensure proper linkage while maintaining whole-archive linking for MSVC.